### PR TITLE
Generator argument -> id fix.

### DIFF
--- a/src/main/java/com/ubempire/not/a/portal/PinappConfig.java
+++ b/src/main/java/com/ubempire/not/a/portal/PinappConfig.java
@@ -62,7 +62,7 @@ public class PinappConfig {
 				String plugin = genSplit[0];
 				String args = "";
 				if (genSplit.length > 1)
-					args = genSplit[1];
+					args = generator.substring(generator.indexOf(":") + 1);
 				ChunkGenerator gen = jp.getServer().getPluginManager()
 						.getPlugin(plugin)
 						.getDefaultWorldGenerator(worldName, args);


### PR DESCRIPTION
`generator` arguments now forwards everything after the first `:`, instead of dropping everything after the occasional second `:`.
